### PR TITLE
料金ページのfooterを下部に固定

### DIFF
--- a/src/app/price-page/price-page.component.html
+++ b/src/app/price-page/price-page.component.html
@@ -1,49 +1,51 @@
-<app-header></app-header>
+<div class="wrapper">
+  <app-header></app-header>
 
-<div class="container">
-  <section class="row header">
-    <h1>{{ title }}</h1>
-    <p>
-      当塾はシンプルな1プランです。
-    </p>
-  </section>
+  <div class="container">
+    <section class="row header">
+      <h1>{{ title }}</h1>
+      <p>
+        当塾はシンプルな1プランです。
+      </p>
+    </section>
 
-  <section class="row price">
-    <div>
+    <section class="row price">
       <div>
-        <p>無料個別相談</p>
-        <p class="free">
-          ミスマッチを防ぐためにもまずは無料個別相談をご利用下さい。
-        </p>
-        <p>0円</p>
-        <app-button
-          text="無料個別相談へ"
-          [height]="45"
-          [width]="262"
-          link="/trial"
-        ></app-button>
+        <div>
+          <p>無料個別相談</p>
+          <p class="free">
+            ミスマッチを防ぐためにもまずは無料個別相談をご利用下さい。
+          </p>
+          <p>0円</p>
+          <app-button
+            text="無料個別相談へ"
+            [height]="45"
+            [width]="262"
+            link="/trial"
+          ></app-button>
+        </div>
+        <div>
+          <p>デポジット（保証金）</p>
+          <p class="basic">
+            一般入試で不合格だった場合は、保証金32万円のうち30万円を返金致します。
+          </p>
+          <p>320,000円</p>
+        </div>
+        <div>
+          <p>授業料</p>
+          <p>
+            ・主要5科目指導<br />
+            ・週1（90分~120分）<br />
+            ・90分を超えることがあるため毎授業30分の延長を付けております。
+          </p>
+          <p>18,900円（税込み）</p>
+        </div>
       </div>
-      <div>
-        <p>デポジット（保証金）</p>
-        <p class="basic">
-          一般入試で不合格だった場合は、保証金32万円のうち30万円を返金致します。
-        </p>
-        <p>320,000円</p>
-      </div>
-      <div>
-        <p>授業料</p>
-        <p>
-          ・主要5科目指導<br />
-          ・週1（90分~120分）<br />
-          ・90分を超えることがあるため毎授業30分の延長を付けております。
-        </p>
-        <p>18,900円（税込み）</p>
-      </div>
-    </div>
-    <p>
-      現在、入塾金はかかりません。<br class="pc-none" />維持費や管理費もかかりません。
-    </p>
-  </section>
+      <p>
+        現在、入塾金はかかりません。<br class="pc-none" />維持費や管理費もかかりません。
+      </p>
+    </section>
+  </div>
+
+  <app-footer></app-footer>
 </div>
-
-<app-footer></app-footer>

--- a/src/app/price-page/price-page.component.scss
+++ b/src/app/price-page/price-page.component.scss
@@ -1,3 +1,10 @@
+.wrapper {
+  min-height: 100vh;
+  position: relative;
+  padding-bottom: 160px;
+  box-sizing: border-box;
+}
+
 .header {
   display: block;
   height: auto;
@@ -95,4 +102,10 @@
       }
     }
   }
+}
+
+app-footer {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
 }

--- a/src/app/price-page/price-page.component.scss
+++ b/src/app/price-page/price-page.component.scss
@@ -1,5 +1,5 @@
 .wrapper {
-  min-height: 100vh;
+  min-height: 93vh;
   position: relative;
   padding-bottom: 160px;
   box-sizing: border-box;


### PR DESCRIPTION
料金ページのコンテンツが少なくなったため、 footerがちょっと上に表示されて下に余白ができてしまうのを修正。

|before|after|
|:-:|:-:|
|<img width="1072" alt="image" src="https://user-images.githubusercontent.com/42249033/154804460-40fd3565-66f9-43f6-bf6c-f34f0d5f72f9.png">|<img width="1059" alt="image" src="https://user-images.githubusercontent.com/42249033/154804790-7d7779f6-b0d7-47f8-9712-aa11805f579a.png">|

